### PR TITLE
Add max_pages to _getUsingCursor to prevent rate limit errors

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -986,7 +986,13 @@ Twitter.prototype.getFriendsIds = function(id, callback) {
 	params.stringify_ids = true
 
 	var url = '/friends/ids.json';
-	this._getUsingCursor(url, params, callback);
+	var opts = {};
+
+	// max_pages is based on twitter api rate limit.
+	// https://dev.twitter.com/rest/reference/get/friends/ids
+	opts.max_pages = 15;
+
+	this._getUsingCursor(url, params, callback, opts);
 	return this;
 };
 
@@ -1010,7 +1016,14 @@ Twitter.prototype.getFollowersIds = function(id, callback) {
 	params.stringify_ids = true
 
 	var url = '/followers/ids.json';
-	this._getUsingCursor(url, params, callback);
+
+	var opts = {};
+
+	// max_pages is based on twitter api rate limit.
+	// https://dev.twitter.com/rest/reference/get/followers/ids
+	opts.max_pages = 15;
+
+	this._getUsingCursor(url, params, callback, opts);
 	return this;
 };
 
@@ -1272,18 +1285,22 @@ Twitter.prototype.getFriendsTimeline = function(params, callback) {
  * INTERNAL UTILITY FUNCTIONS
  */
 
-Twitter.prototype._getUsingCursor = function(url, params, callback) {
+Twitter.prototype._getUsingCursor = function(url, params, callback, opts) {
 	var key,
 	  result = [],
 	  self = this;
 
 	params = params || {};
 	key = params.key || null;
+	opts = opts || {};
+	max_pages = opts.max_pages || Infinity;
 
 	// if we don't have a key to fetch, we're screwed
 	if (!key)
 		callback(new Error('FAIL: Results key must be provided to _getUsingCursor().'));
 	delete params.key;
+
+	var nextPageNum = 1;
 
 	// kick off the first request, using cursor -1
 	params = merge(params, {cursor:-1});
@@ -1295,10 +1312,12 @@ Twitter.prototype._getUsingCursor = function(url, params, callback) {
 			return;
 		}
 
+		nextPageNum++;
+
 		// FIXME: what if data[key] is not a list?
 		if (data[key]) result = result.concat(data[key]);
 
-		if (data.next_cursor_str === '0') {
+		if ((data.next_cursor_str === '0') || (nextPageNum > max_pages)) {
 			callback(null, result);
 		} else {
 			params.cursor = data.next_cursor_str;

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -986,13 +986,13 @@ Twitter.prototype.getFriendsIds = function(id, callback) {
 	params.stringify_ids = true
 
 	var url = '/friends/ids.json';
-	var opts = {};
+	var options = {};
 
-	// max_pages is based on twitter api rate limit.
+	// maxPages is based on twitter api rate limit.
 	// https://dev.twitter.com/rest/reference/get/friends/ids
-	opts.max_pages = 15;
+	options.maxPages = 15;
 
-	this._getUsingCursor(url, params, callback, opts);
+	this._getUsingCursor(url, params, callback, options);
 	return this;
 };
 
@@ -1017,13 +1017,13 @@ Twitter.prototype.getFollowersIds = function(id, callback) {
 
 	var url = '/followers/ids.json';
 
-	var opts = {};
+	var options = {};
 
-	// max_pages is based on twitter api rate limit.
+	// maxPages is based on twitter api rate limit.
 	// https://dev.twitter.com/rest/reference/get/followers/ids
-	opts.max_pages = 15;
+	options.maxPages = 15;
 
-	this._getUsingCursor(url, params, callback, opts);
+	this._getUsingCursor(url, params, callback, options);
 	return this;
 };
 
@@ -1285,15 +1285,15 @@ Twitter.prototype.getFriendsTimeline = function(params, callback) {
  * INTERNAL UTILITY FUNCTIONS
  */
 
-Twitter.prototype._getUsingCursor = function(url, params, callback, opts) {
+Twitter.prototype._getUsingCursor = function(url, params, callback, options) {
 	var key,
 	  result = [],
 	  self = this;
 
 	params = params || {};
 	key = params.key || null;
-	opts = opts || {};
-	max_pages = opts.max_pages || Infinity;
+	options = options || {};
+	maxPages = options.maxPages || Infinity;
 
 	// if we don't have a key to fetch, we're screwed
 	if (!key)
@@ -1317,7 +1317,7 @@ Twitter.prototype._getUsingCursor = function(url, params, callback, opts) {
 		// FIXME: what if data[key] is not a list?
 		if (data[key]) result = result.concat(data[key]);
 
-		if ((data.next_cursor_str === '0') || (nextPageNum > max_pages)) {
+		if ((data.next_cursor_str === '0') || (nextPageNum > maxPages)) {
 			callback(null, result);
 		} else {
 			params.cursor = data.next_cursor_str;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "twitter",
-    "version": "v0.2.13",
+    "version": "v0.2.14",
     "description": "Twitter API client library for node.js",
     "keywords": [
         "twitter",


### PR DESCRIPTION
Only adding this to the two APIs that we use for now. We may want to change this and pass max_pages in so we can adjust the rate limits in our app's config. Or perhaps be smarter and wait the 15 minutes so we can continue to paginate. But for now, 75,000 friends/followers ids is good enough.

/ht @gasi for finding the bug.